### PR TITLE
Correct putative typo

### DIFF
--- a/Lecture 1- Intro and Simulation Methods/lecture1_simulation.tex
+++ b/Lecture 1- Intro and Simulation Methods/lecture1_simulation.tex
@@ -352,7 +352,7 @@ f _ { Y | X } ( y | x , \beta _ { 0 } ) =  { e } ^ { x ^ { \prime } \beta _ { 0 
 \end{align*}
 With log likelihood
 \begin{align*}
-l( \beta ) = \sum _ { i = 1 } ^ { N } \ln f _ { Y | X } \left( y _ { i } | x _ { i } , \beta \right) = \sum _ { i = 1 } ^ { N } X _ { i } ^ { \prime } \beta - y _ { i } \cdot \exp \left( x _ { i } ^ { \prime } \beta \right)
+l( \beta ) = \sum _ { i = 1 } ^ { N } \ln f _ { Y | X } \left( y _ { i } | x _ { i } , \beta \right) = \sum _ { i = 1 } ^ { N } x _ { i } ^ { \prime } \beta - y _ { i } \cdot \exp \left( x _ { i } ^ { \prime } \beta \right)
 \end{align*}
 And Score, Hessian, and Information Matrix:
 \begin{align*}


### PR DESCRIPTION
I believe this should be a small `x` if the notation assume it to be a vector, but chiefly I'm just trying out the pull-request-as-coursework feature. (Sorry if it messes anything up.)